### PR TITLE
Manage DNS in NetworkManager config directly.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,14 +16,12 @@ platforms:
         - apt-get update && apt-get install -y locales ifupdown network-manager
         - locale-gen en_US.UTF-8
         - update-locale LANG=en_US.UTF-8
-        - cat /etc/NetworkManager/NetworkManager.conf /proc/1/cpuset
       run_command: /lib/systemd/systemd
   - name: centos-7-with-network-manager
     driver_config:
       image: centos:7
       provision_command:
         - yum install NetworkManager -y
-        - cat /etc/NetworkManager/NetworkManager.conf /proc/1/cpuset
       run_command: /usr/lib/systemd/systemd
 
 provisioner:

--- a/pillar.example
+++ b/pillar.example
@@ -4,8 +4,8 @@ resolver:
     resolvconf:
       enabled: False
     networkmanager:
-      #By default we disable networkmanager owning resolv.conf to avoid conflict 
-      disable_resolvconf: True
+      # Disable DNS management in NetworkManager.
+      managed: True
       file: /etc/NetworkManager/NetworkManager.conf
   domain: example.com
   nameservers:

--- a/resolver/ng/defaults.yaml
+++ b/resolver/ng/defaults.yaml
@@ -5,15 +5,10 @@ Defaults:
       remove: True
       file: /run/resolvconf/resolv.conf
     networkmanager:
-      ### For preventing NM managing resolvconf
-      disable_resolvconf: True
+      # Disable DNS management in NetworkManager.
+      managed: True
       file: /etc/NetworkManager/NetworkManager.conf
       service: NetworkManager
-      regex:
-       {% raw %}
-        - ['santize', '^(?!#)(?:\s?dns\s?=.*$)', "''",]
-        - ['none', '^(?!#)(\s?\[\s?main\s?\].*$\n+)^(?:\s?dns\s?=\s?.*)?(.*)', '\1\ndns=none\n\2',]
-       {% endraw %}
   nameservers:
     - 8.8.8.8
     - 8.8.4.4

--- a/resolver/ng/init.sls
+++ b/resolver/ng/init.sls
@@ -41,26 +41,25 @@
       - file: {{ sls }}~update-resolv.conf-file
 {% endif %}
 
-    {### Prevent NetworkManager managing resolvconf ###}
-  {% if salt['file.file_exists']( resolver.ng.networkmanager.file ) %}
-    {% if resolver.ng.networkmanager.disable_resolvconf %}
-      {% for config in resolver.ng.networkmanager.regex %}
+# Prevent NetworkManager managing resolv.conf file.
+{% if salt['file.file_exists'](resolver.ng.networkmanager.file)
+      and resolver.ng.networkmanager.managed %}
 
-{{ sls }}_networkmanager_dns_{{ config[0] }}:
-  file.replace:
+{{ sls }}~networkmanager_dns:
+  ini.options_present:
     - name: {{ resolver.ng.networkmanager.file }}
-    - pattern: {{ config[1] }}
-    - repl: {{ config[2] }}
-    - flags: ['IGNORECASE', 'MULTILINE']
+    - separator: '='
+    - strict: False
+    - sections:
+        main:
+          dns: 'none'
     - onlyif: systemctl is-enabled {{ resolver.ng.networkmanager.service }}
     - require:
       - file: {{ sls }}~update-resolv.conf-file
     - watch_in:
-      - service: {{ sls }}_networkmanager_dns_{{ config[0] }}
+      - service: {{ sls }}~networkmanager_dns
   service.running:
     - name: {{ resolver.ng.networkmanager.service }}
     - enable: True
 
-      {% endfor %}
-    {% endif %}
-  {% endif %}
+{% endif %}


### PR DESCRIPTION
Hello @noelmcloughlin 

Since NetworkManager config file is simply just an ini file, so it's better to manage it directly rather than doing find and replace.

And it's working with Ubuntu and CentOS without problems.

Thanks.